### PR TITLE
Android: Fixes #0: Harden failsafe logic to check for the presence of info.json, rather than just the item count

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -862,8 +862,7 @@ export default class Synchronizer {
 					// Ensure that if the sync target directory has changed, lost access, or has been purged by some external process while the sync is running, that a failsafe error is triggered where info.json and .sync/version.txt can no longer be found
 					// This check is more reliable than checking the count of items alone, as it is possible for sync items become segmented between 2 directories, possibly by the target directory changing during sync
 					// This scenario is possible with OneDrive sync, see https://github.com/laurent22/joplin/issues/11489
-					// It is still useful to keep the failsafe check which is driven by count of items as well, to protect against deliberate deletion of all notes by the user, where they are not aware of the implications of 2 way sync
-					// This check during the sync is only necessary for the delta step of the sync, as this is where local deletions are calculated by comparing the local database and the sync target. These deletions are driven by the listResult field to determine which remote items exist
+					// This check while the sync is running is only necessary for the delta step of the sync, as this is where local deletions are calculated by comparing the local database and the sync target. These deletions are driven by the listResult field to determine which remote items exist
 					// As long as we check that info.json still exists after each time the listResult field is repopulated, there should not be a risk of unwanted deletions when failsafe is enabled, unless the target directory is directly manipulated by the user
 					await checkSyncTargetIsValid(this.api());
 

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -22,7 +22,7 @@ import TaskQueue from './TaskQueue';
 import ItemUploader from './services/synchronizer/ItemUploader';
 import { FileApi, getSupportsDeltaWithItems, PaginatedList, RemoteItem } from './file-api';
 import JoplinDatabase from './JoplinDatabase';
-import { checkIfCanSync, fetchSyncInfo, getActiveMasterKey, localSyncInfo, mergeSyncInfos, saveLocalSyncInfo, setMasterKeyHasBeenUsed, SyncInfo, syncInfoEquals, uploadSyncInfo } from './services/synchronizer/syncInfoUtils';
+import { checkIfCanSync, fetchSyncInfo, checkSyncTargetIsValid, getActiveMasterKey, localSyncInfo, mergeSyncInfos, saveLocalSyncInfo, setMasterKeyHasBeenUsed, SyncInfo, syncInfoEquals, uploadSyncInfo } from './services/synchronizer/syncInfoUtils';
 import { getMasterPassword, setupAndDisableEncryption, setupAndEnableEncryption } from './services/e2ee/utils';
 import { generateKeyPair } from './services/e2ee/ppk';
 import syncDebugLog from './services/synchronizer/syncDebugLog';
@@ -472,7 +472,7 @@ export default class Synchronizer {
 			this.api().setTempDirName(Dirnames.Temp);
 
 			try {
-				let remoteInfo = await fetchSyncInfo(this.api());
+				let remoteInfo = await fetchSyncInfo(this.api(), true);
 				logger.info('Sync target remote info:', remoteInfo.filterSyncInfo());
 				eventManager.emit(EventName.SessionEstablished);
 
@@ -858,6 +858,14 @@ export default class Synchronizer {
 
 						logger: logger,
 					});
+
+					// Ensure that if the sync target directory has changed, lost access, or has been purged by some external process while the sync is running, that a failsafe error is triggered where info.json and .sync/version.txt can no longer be found
+					// This check is more reliable than checking the count of items alone, as it is possible for sync items become segmented between 2 directories, possibly by the target directory changing during sync
+					// This scenario is possible with OneDrive sync, see https://github.com/laurent22/joplin/issues/11489
+					// It is still useful to keep the failsafe check which is driven by count of items as well, to protect against deliberate deletion of all notes by the user, where they are not aware of the implications of 2 way sync
+					// This check during the sync is only necessary for the delta step of the sync, as this is where local deletions are calculated by comparing the local database and the sync target. These deletions are driven by the listResult field to determine which remote items exist
+					// As long as we check that info.json still exists after each time the listResult field is repopulated, there should not be a risk of unwanted deletions when failsafe is enabled, unless the target directory is directly manipulated by the user
+					await checkSyncTargetIsValid(this.api());
 
 					const supportsDeltaWithItems = getSupportsDeltaWithItems(listResult);
 

--- a/packages/lib/services/synchronizer/syncInfoUtils.test.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.test.ts
@@ -1,7 +1,9 @@
-import { afterAllCleanUp, setupDatabaseAndSynchronizer, logger, switchClient, encryptionService, msleep } from '../../testing/test-utils';
+import { afterAllCleanUp, setupDatabaseAndSynchronizer, logger, switchClient, encryptionService, msleep, fileApi } from '../../testing/test-utils';
 import MasterKey from '../../models/MasterKey';
-import { checkIfCanSync, localSyncInfo, masterKeyEnabled, mergeSyncInfos, saveLocalSyncInfo, setMasterKeyEnabled, SyncInfo, syncInfoEquals } from './syncInfoUtils';
+import { checkIfCanSync, localSyncInfo, masterKeyEnabled, mergeSyncInfos, saveLocalSyncInfo, setMasterKeyEnabled, SyncInfo, syncInfoEquals, checkSyncTargetIsValid, fetchSyncInfo } from './syncInfoUtils';
 import Setting from '../../models/Setting';
+import BaseItem from '../../models/BaseItem';
+import BaseModel from '../../models/BaseItem';
 import Logger from '@joplin/utils/Logger';
 
 describe('syncInfoUtils', () => {
@@ -9,6 +11,7 @@ describe('syncInfoUtils', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
 		await switchClient(1);
+		await fileApi().clearRoot();
 	});
 
 	afterAll(async () => {
@@ -326,4 +329,121 @@ describe('syncInfoUtils', () => {
 
 		Logger.globalLogger.enabled = true;
 	});
+
+	it('should succeed when info.json exists for checkSyncTargetIsValid', (async () => {
+		Setting.setValue('sync.wipeOutFailSafe', true);
+		const syncInfo = new SyncInfo();
+		await fileApi().put('info.json', syncInfo.serialize());
+
+		let errorMsg = null;
+		try {
+			await checkSyncTargetIsValid(fileApi());
+		} catch (error) {
+			errorMsg = error.message;
+		}
+
+		expect(errorMsg).toBe(null);
+	}));
+
+	it('should succeed when info.json does not exist and failsafe is disabled for checkSyncTargetIsValid', (async () => {
+		Setting.setValue('sync.wipeOutFailSafe', false);
+		let errorMsg = null;
+		try {
+			await checkSyncTargetIsValid(fileApi());
+		} catch (error) {
+			errorMsg = error.message;
+		}
+
+		expect(errorMsg).toBe(null);
+	}));
+
+	it('should fail with failsafe error when info.json does not exist for checkSyncTargetIsValid', (async () => {
+		Setting.setValue('sync.wipeOutFailSafe', true);
+		let errorMsg = null;
+		try {
+			await checkSyncTargetIsValid(fileApi());
+		} catch (error) {
+			errorMsg = error.message;
+		}
+
+		expect(errorMsg).toBe('Fail-safe: Sync was interrupted to prevent data loss, because the sync target is empty or damaged. To override this behaviour disable the fail-safe in the sync settings.');
+	}));
+
+	it('should succeed when info.json exists and is valid for fetchSyncInfo', (async () => {
+		Setting.setValue('sync.wipeOutFailSafe', true);
+		const expectedSyncInfo = new SyncInfo();
+		expectedSyncInfo.version = 50;
+		await fileApi().put('info.json', expectedSyncInfo.serialize());
+
+		const actualSyncInfo = await fetchSyncInfo(fileApi(), false);
+		expect(actualSyncInfo).toStrictEqual(expectedSyncInfo);
+	}));
+
+	it('should fail with missing version error when info.json exists but is invalid for fetchSyncInfo', (async () => {
+		Setting.setValue('sync.wipeOutFailSafe', true);
+		await fileApi().put('info.json', new SyncInfo().serialize());
+
+		let errorMsg = null;
+		try {
+			await fetchSyncInfo(fileApi(), false);
+		} catch (error) {
+			errorMsg = error.message;
+		}
+		expect(errorMsg).toBe('Missing "version" field in info.json');
+	}));
+
+	it('should succeed when info.json does not exist but .sync/version.txt does exist for fetchSyncInfo', (async () => {
+		Setting.setValue('sync.wipeOutFailSafe', true);
+		await fileApi().put('.sync/version.txt', '{}');
+
+		const actualSyncInfo = await fetchSyncInfo(fileApi(), false);
+		expect(actualSyncInfo.version).toBe(1);
+	}));
+
+	it('should succeed when info.json and .sync/version.txt does not exist and failsafe is disabled for fetchSyncInfo', (async () => {
+		Setting.setValue('sync.wipeOutFailSafe', false);
+
+		const actualSyncInfo = await fetchSyncInfo(fileApi(), false);
+		expect(actualSyncInfo.version).toBe(0);
+	}));
+
+	it('should fail with failsafe error when info.json and .sync/version.txt does not exist for fetchSyncInfo', (async () => {
+		Setting.setValue('sync.wipeOutFailSafe', true);
+
+		let errorMsg = null;
+		try {
+			await fetchSyncInfo(fileApi(), false);
+		} catch (error) {
+			errorMsg = error.message;
+		}
+		expect(errorMsg).toBe('Fail-safe: Sync was interrupted to prevent data loss, because the sync target is empty or damaged. To override this behaviour disable the fail-safe in the sync settings.');
+	}));
+
+	it('should fail with failsafe error when info.json and .sync/version.txt does not exist when checkSyncedItems is true and sync items are present for fetchSyncInfo', (async () => {
+		Setting.setValue('sync.wipeOutFailSafe', true);
+		const note = {
+			id: 1,
+			type_: BaseModel.TYPE_NOTE,
+		};
+		await BaseItem.saveSyncTime(fileApi().syncTargetId(), note, 1);
+
+		let errorMsg = null;
+		try {
+			await fetchSyncInfo(fileApi(), true);
+		} catch (error) {
+			errorMsg = error.message;
+		}
+		expect(errorMsg).toBe('Fail-safe: Sync was interrupted to prevent data loss, because the sync target is empty or damaged. To override this behaviour disable the fail-safe in the sync settings.');
+	}));
+
+	it('should succeed when info.json and .sync/version.txt does not exist when checkSyncedItems is true and sync items are not present for fetchSyncInfo', (async () => {
+		Setting.setValue('sync.wipeOutFailSafe', true);
+		let errorMsg = null;
+		try {
+			await fetchSyncInfo(fileApi(), true);
+		} catch (error) {
+			errorMsg = error.message;
+		}
+		expect(errorMsg).toBe(null);
+	}));
 });

--- a/packages/lib/services/synchronizer/syncInfoUtils.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.ts
@@ -118,9 +118,16 @@ export async function checkSyncTargetIsValid(api: FileApi): Promise<void> {
 	}
 }
 
+// This failsafe validation will be performed regardless of which sync target is selected
+// Other failsafe validation is performed based on the percentage of items deleted in the "basicDelta" function
+// The basicDelta is not executed for all sync target types, but the validation in this function is superior at protecting against data loss
+// However it is still beneficial to keep the failsafe check which is driven by count of deleted items in place, as it can protect against deliberate deletion of all notes by the user,
+// where they are not aware of the implications of 2 way sync. This is just "nice to have" though, so would not be worth adding complexity to make it work for all sync target types
 async function performFailsafeValidation(api: FileApi, checkSyncedItems = false) {
 	// When setting up a new sync target, info.json and .sync/version.txt will not yet exist on remote
 	// checkSyncedItems should be passed as true for this scenario, to bypass the failsafe error where the sync target has never been synced
+	// When performing 'Delete local data and re-download from sync target' or 'Re-upload local data to sync target' actions, all sync_items are cleared down,
+	// so they will bypass the error here, as if it was a new sync target
 	let bypassFailsafe = false;
 	if (checkSyncedItems) {
 		const syncedItems = await BaseItem.syncedItemIds(api.syncTargetId());


### PR DESCRIPTION
In the past 3-4 months there have been a number of issues raised on the support forum where Joplin users who use OneDrive sync have claimed that their notes 'suddenly disappeared'. While it is not possible to determine if all cases were caused by the same issue, there is evidence through user feedback from [@BeefStorm](https://discourse.joplinapp.org/u/beefstorm) on this thread [Restore Deleted Backups - #18 by BeefStorm](https://discourse.joplinapp.org/t/restore-deleted-backups/43230/18) that this issue can occur without any user interaction, via a re-authentication of OneDrive happening in the background, which may sometimes cause the sync target (special) folder on OneDrive to change and somehow bypass the failsafe mechanism when that occurs.

I proposed and have now implemented a method for how the failsafe could be hardened to be more protective from data loss on all sync targets. In summary:
During the delta step of the synchronization code, make it check whether the sync target (remote) contains an info.json file, following each invocation of the delta api which fetches the list of remote items, and also when synchronization is started (just before info.json is created). If it does not, then trigger a failsafe error specifying that the sync target is empty or damaged. To avoid hitting this error when doing the initial sync on a device, bypass this error if the local database contains no items in the sync_items table matching the current sync target (then when it starts syncing it will create the info.json so that subsequent syncs should work without issue).

I have tested the following scenarios using a profile containing at least a couple of notes:
-Test setting up a new sync target with file system sync, when sync has never been set up before: The sync completes without issues, regardless of whether failsafe is enabled
-Test setting up a new sync target with onedrive sync, when sync has never been set up before: The sync completes without issues, regardless of whether failsafe is enabled
-Test setting up a new sync target with onedrive sync, when sync has never been set up before for onedrive, but has for file system sync: The sync completes without issues, regardless of whether failsafe is enabled
-Test setting up file system sync and syncing fully, then setting up onedrive sync and syncing fully, then switching back to file system sync on the same directly but with the .sync folder and info.json deleted: This should trigger the error if failsafe is enabled, or no error if it is not
-Test .sync folder and info.json being deleted for file system sync for an existing target, then trigger the sync: This should trigger the error if failsafe is enabled, or no error if it is not
-Test failsafe check during the delta step: Make 60 dummy notes, duplicate them and click sync. As the sync status starts notifying of items created, delete the .sync folder and info.json before it completes. This should trigger a failsafe error if failsafe is enabled, or complete the sync if it is not
-Test upgrading the sync target by deleting info.json but not .sync/version.txt: This should work correctly, prompting the user to upgrade via a banner, and upong restarting via this banner the sync should be restored and the info.json file gets recreated. Note that on the desktop, the upgrade banner is dismissed if switching note after it shows, and requires restart of Joplin for it to come back, after which the message is persistent. Note that this is existing behaviour
-Test 'Delete local data and re-download from sync target' option: It should work correctly without errors and sync continues to work afterwards (tested with OneDrive)
-Test 'Re-upload local data to sync target' option: It should work correctly without errors and sync continues to work afterwards (tested with OneDrive)
-Test 'Delete local data and re-download from sync target' option with the .sync folder and info.json deleted: It should work correctly without errors and sync continues to work afterwards (tested with file system sync). Also when deleting just info.json, it triggers the sync upgrade banner, and upon restarting via the banner the sync completes successfully
-Test 'Re-upload local data to sync target' option with the .sync folder and info.json deleted: It should work correctly without errors and sync continues to work afterwards (tested with file system sync). Also when deleting just info.json, it triggers the sync upgrade banner, and upon restarting via the banner the sync completes successfully