### PR TITLE
Desktop, Mobile: Trigger sync one more time if there are unsynced outgoing changes when sync completes

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -387,7 +387,7 @@ export default class Synchronizer {
 	// 2. DELETE_REMOTE: Delete on the sync target, the items that have been deleted locally.
 	// 3. DELTA: Find on the sync target the items that have been modified or deleted and apply the changes locally.
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public async start(options: any = null) {
+	public async start(options: any = null): Promise<any> {
 		if (!options) options = {};
 
 		if (this.state() !== 'idle') {
@@ -1190,6 +1190,11 @@ export default class Synchronizer {
 
 		if (errorToThrow) throw errorToThrow;
 
-		return outputContext;
+		// If there are any un-synced outgoing changes made up to the point just before the sync completes, then trigger the sync again to reduce the likelihood
+		// that the user will close the app when there are un-synced changed, because they think the sync has completed
+		const result = await BaseItem.itemsThatNeedSync(syncTargetId);
+		options.context = outputContext;
+
+		return (result.items.length > 0) ? await this.start(options) : outputContext;
 	}
 }

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -1191,7 +1191,7 @@ export default class Synchronizer {
 		if (errorToThrow) throw errorToThrow;
 
 		// If there are any un-synced outgoing changes made up to the point just before the sync completes, then trigger the sync again to reduce the likelihood
-		// that the user will close the app when there are un-synced changed, because they think the sync has completed
+		// that the user will close or minimise the app when there are un-synced changes, because they think the sync has completed
 		const result = await BaseItem.itemsThatNeedSync(syncTargetId);
 		options.context = outputContext;
 


### PR DESCRIPTION
On mobile, sync is triggered continuously as the user types. This helps to ensure that the latest changes get uploaded to the server, particularly because the Joplin mobile app does not support syncing in the background. Due to the synchronization process having multiple stages, it is possible that the continuous sync can stop prior to the latest change being uploaded, for the last characters the user enters when finishing editing a note. This is because if changes are saved during the delta step of the sync process (which runs last), the loop for the changes to upload would have ended at this point. This can result in conflicts, if the user closes or minimises the app after this happens (which is likely, because the sidebar would show that the sync is completed), and then starts using Joplin on another device.

In order to remedy this, I have added a check at the very end of the synchronization process, which checks again if there are any pending outgoing changes. If this is the case, the sync will be triggered again, similar to if a change was made just after the sync has completed. This will happen recursively until there are no outgoing changes pending, at the last part of the execution of the synchronizer logic.

### Testing

To test this, on Android emulator, I have used the Extended Markdown editor settings plugin, which has a feature to show a visual sync indicator in the note editor screen. When the above scenario is produced, the editing icon is displayed indefinitely on the plugin's sync indicator after stopping typing, and this only goes away if exiting edit mode or starting typing again, which triggers the sync again. When exiting the editor when the indicator is 'stuck' on the editing icon, manually triggering the sync would show 1 update being uploaded for the change that was outstanding.

After applying this code change, when the plugin's sync indicator is stuck on the editing icon, exiting the note editor and manually triggering the sync shows fetches only, and no updates being made. Also, in the log you are able to see 2 sets of sync summaries which are a couple of seconds apart.

On desktop and mobile, I have also verified that manually syncing on the note list screen will end after the only one sync completes (and not get stuck in an infinite loop), when nothing is being changed.