### PR TITLE
All: Prevent Joplin sync ignoring changes when syncing with an external sync service concurrently

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1394,6 +1394,7 @@ packages/lib/services/database/migrations/45.js
 packages/lib/services/database/migrations/46.js
 packages/lib/services/database/migrations/47.js
 packages/lib/services/database/migrations/48.js
+packages/lib/services/database/migrations/49.js
 packages/lib/services/database/migrations/index.js
 packages/lib/services/database/sqlStringToLines.js
 packages/lib/services/database/types.js

--- a/.gitignore
+++ b/.gitignore
@@ -1367,6 +1367,7 @@ packages/lib/services/database/migrations/45.js
 packages/lib/services/database/migrations/46.js
 packages/lib/services/database/migrations/47.js
 packages/lib/services/database/migrations/48.js
+packages/lib/services/database/migrations/49.js
 packages/lib/services/database/migrations/index.js
 packages/lib/services/database/sqlStringToLines.js
 packages/lib/services/database/types.js

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -1015,7 +1015,7 @@ export default class Synchronizer {
 							// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 							const options: any = {
 								autoTimestamp: false,
-								nextQueries: BaseItem.updateSyncTimeQueries(syncTargetId, content, time.unixMs(), undefined, undefined, undefined, remote.updated_time),
+								nextQueries: BaseItem.updateSyncTimeQueries(syncTargetId, content, time.unixMs(), remote.updated_time),
 								changeSource: ItemChange.SOURCE_SYNC,
 							};
 							if (action === SyncAction.CreateLocal) options.isNew = true;

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -804,6 +804,15 @@ export default class Synchronizer {
 								// on it (instead it uses a more reliable `context` object) and the itemsThatNeedSync loop
 								// above also doesn't use it because it fetches the whole remote object and read the
 								// more reliable 'updated_time' property. Basically remote.updated_time is deprecated.
+								// 2025-08-27: remote.updated_time can now be utilised by the basic delta when using a sync target
+								// where the 'server' is actually the same device that is running the client eg. file system sync.
+								// This is required to correctly detect updated objects where an external sync service is being
+								// used in combination with Joplin, as there are essentially multiple sources of truth, rather
+								// than just one. So we can't rely on the server always containing the latest remote changes
+								// during synchronization, as new changes can be later added which have a timestamp in the past.
+								// In this scenario, we don't know the exact timestamp to specify for remoteItemUpdatedTime upon
+								// uploading. So we can leave it unspecified and then on the next run of the delta step, it will
+								// get set there
 
 								await ItemClass.saveSyncTime(syncTargetId, local, local.updated_time);
 							}
@@ -862,6 +871,11 @@ export default class Synchronizer {
 						// drivers with a delta functionality it's a noop.
 						allItemIdsHandler: async () => {
 							return BaseItem.syncedItemIds(syncTargetId);
+						},
+
+						// This is only used by the basic delta
+						allItemMetadataHandler: async () => {
+							return BaseItem.remoteItemMetadata(syncTargetId);
 						},
 
 						wipeOutFailSafe: Setting.value('sync.wipeOutFailSafe'),
@@ -996,7 +1010,7 @@ export default class Synchronizer {
 							// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 							const options: any = {
 								autoTimestamp: false,
-								nextQueries: BaseItem.updateSyncTimeQueries(syncTargetId, content, time.unixMs()),
+								nextQueries: BaseItem.updateSyncTimeQueries(syncTargetId, content, time.unixMs(), undefined, undefined, undefined, remote.updated_time),
 								changeSource: ItemChange.SOURCE_SYNC,
 							};
 							if (action === SyncAction.CreateLocal) options.isNew = true;

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -974,7 +974,7 @@ export default class Synchronizer {
 										} else if (Setting.value('sync.detectBasedOnAnyTimestampChanges') && content && content.updated_time === local.updated_time) {
 											// When initially enabling detectBasedOnAnyTimestampChanges, all items are rescanned and we need to persist the remoteItemUpdatedTime
 											// to set up the initial synced state
-											await ItemClass.saveSyncTime(syncTargetId, local, local.updated_time, content.updated_time);
+											await ItemClass.saveSyncTime(syncTargetId, local, local.updated_time, remote.updated_time);
 										}
 									}
 								}

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -971,9 +971,10 @@ export default class Synchronizer {
 										if (content && content.updated_time > local.updated_time) {
 											action = SyncAction.UpdateLocal;
 											reason = 'remote is more recent than local';
-										} else if (Setting.value('sync.detectBasedOnAnyTimestampChanges') && content && content.updated_time === local.updated_time) {
+										} else if (Setting.value('sync.detectBasedOnAnyTimestampChanges')) {
 											// When initially enabling detectBasedOnAnyTimestampChanges, all items are rescanned and we need to persist the remoteItemUpdatedTime
-											// to set up the initial synced state
+											// to set up the initial synced state. This also catches the case if content.updated_time < local.updated_time due to manual manipulation
+											// of the md files, to prevent these items being continually fetched on every sync
 											await ItemClass.saveSyncTime(syncTargetId, local, local.updated_time, remote.updated_time);
 										}
 									}

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -971,6 +971,10 @@ export default class Synchronizer {
 										if (content && content.updated_time > local.updated_time) {
 											action = SyncAction.UpdateLocal;
 											reason = 'remote is more recent than local';
+										} else if (Setting.value('sync.detectBasedOnAnyTimestampChanges') && content && content.updated_time === local.updated_time) {
+											// When initially enabling detectBasedOnAnyTimestampChanges, all items are rescanned and we need to persist the remoteItemUpdatedTime
+											// to set up the initial synced state
+											await ItemClass.saveSyncTime(syncTargetId, local, local.updated_time, content.updated_time);
 										}
 									}
 								}

--- a/packages/lib/file-api.ts
+++ b/packages/lib/file-api.ts
@@ -1,12 +1,13 @@
 import Logger, { LoggerWrapper } from '@joplin/utils/Logger';
 import shim from './shim';
-import BaseItem from './models/BaseItem';
+import BaseItem, { RemoteItemMetadata } from './models/BaseItem';
 import time from './time';
 
 const { isHidden } = require('./path-utils');
 import JoplinError from './JoplinError';
 import { Lock, LockClientType, LockType } from './services/synchronizer/LockHandler';
 import * as ArrayUtils from './ArrayUtils';
+import Setting from './models/Setting';
 const { sprintf } = require('sprintf-js');
 const Mutex = require('async-mutex').Mutex;
 
@@ -102,6 +103,7 @@ async function tryAndRepeat(fn: Function, count: number) {
 
 export interface DeltaOptions {
 	allItemIdsHandler(): Promise<string[]>;
+	allItemMetadataHandler(): Promise<Map<string, RemoteItemMetadata>>;
 	logger?: LoggerWrapper;
 	wipeOutFailSafe: boolean;
 }
@@ -453,7 +455,8 @@ function basicDeltaContextFromOptions_(options: any) {
 // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any -- Old code before rule was applied, Old code before rule was applied
 async function basicDelta(path: string, getDirStatFn: Function, options: DeltaOptions) {
 	const outputLimit = 50;
-	const itemIds = await options.allItemIdsHandler();
+	const itemIds: string[] = await options.allItemIdsHandler();
+
 	if (!Array.isArray(itemIds)) throw new Error('Delta API not supported - local IDs must be provided');
 
 	const logger = options && options.logger ? options.logger : new Logger();
@@ -494,6 +497,12 @@ async function basicDelta(path: string, getDirStatFn: Function, options: DeltaOp
 		equal: 0,
 	};
 
+	let remoteItemMetadata: Map<string, RemoteItemMetadata>;
+
+	if (Setting.value('sync.detectBasedOnAnyTimestampChanges')) {
+		remoteItemMetadata = await options.allItemMetadataHandler();
+	}
+
 	// Find out which files have been changed since the last time. Note that we keep
 	// both the timestamp of the most recent change, *and* the items that exactly match
 	// this timestamp. This to handle cases where an item is modified while this delta
@@ -507,33 +516,72 @@ async function basicDelta(path: string, getDirStatFn: Function, options: DeltaOp
 		const stat = newContext.statsCache[i];
 
 		if (stat.isDir) continue;
+		if (!BaseItem.isSystemPath(stat.path)) continue;
 
-		if (stat.updated_time < context.timestamp) {
-			updateReport.older++;
-			continue;
-		}
+		let lastRemoteItemUpdatedTime = 0;
+		const itemId = BaseItem.pathToId(stat.path);
 
-		// Special case for items that exactly match the timestamp
-		if (stat.updated_time === context.timestamp) {
-			if (context.filesAtTimestamp.indexOf(stat.path) >= 0) {
-				updateReport.equal++;
+		if (Setting.value('sync.detectBasedOnAnyTimestampChanges')) {
+			const metadata = remoteItemMetadata.get(itemId);
+
+			if (metadata) {
+				// Check if update is needed
+				lastRemoteItemUpdatedTime = metadata.updated_time;
+
+				if (stat.updated_time === lastRemoteItemUpdatedTime) {
+					// Item has already been synced and is up to date
+					updateReport.equal++;
+					continue;
+				}
+
+				if (stat.updated_time < lastRemoteItemUpdatedTime) {
+					updateReport.older++;
+				}
+
+				if (stat.updated_time > lastRemoteItemUpdatedTime) {
+					updateReport.newer++;
+				}
+			} else {
+				// Item needs to be created locally
+				updateReport.newer++;
+			}
+
+			output.push(stat);
+		} else {
+			if (stat.updated_time < context.timestamp) {
+				updateReport.older++;
 				continue;
 			}
-		}
 
-		if (stat.updated_time > newContext.timestamp) {
-			newContext.timestamp = stat.updated_time;
-			newContext.filesAtTimestamp = [];
-			updateReport.newer++;
-		}
+			// Special case for items that exactly match the timestamp
+			if (stat.updated_time === context.timestamp) {
+				if (context.filesAtTimestamp.indexOf(stat.path) >= 0) {
+					updateReport.equal++;
+					continue;
+				}
+			}
 
-		newContext.filesAtTimestamp.push(stat.path);
-		output.push(stat);
+			if (stat.updated_time > newContext.timestamp) {
+				newContext.timestamp = stat.updated_time;
+				newContext.filesAtTimestamp = [];
+				updateReport.newer++;
+			}
+
+			newContext.filesAtTimestamp.push(stat.path);
+			output.push(stat);
+		}
 
 		if (output.length >= outputLimit) break;
 	}
 
-	logger.info(`BasicDelta: Report: ${JSON.stringify(updateReport)}`);
+	if (Setting.value('sync.detectBasedOnAnyTimestampChanges')) {
+		// context.timestamp and filesAtTimestamp are not required when syncing based on any timestamp changes, but should be updated for backwards compatibility
+		newContext.timestamp = time.unixMs();
+		newContext.filesAtTimestamp = [];
+		logger.info(`BasicDelta (with syncBasedOnTimestampChanges): Report: ${JSON.stringify(updateReport)}`);
+	} else {
+		logger.info(`BasicDelta: Report: ${JSON.stringify(updateReport)}`);
+	}
 
 	if (!newContext.deletedItemsProcessed) {
 		// Find out which items have been deleted on the sync target by comparing the items

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -884,7 +884,7 @@ export default class BaseItem extends BaseModel {
 				params: [syncTarget, itemType, itemId],
 			},
 			{
-				sql: 'INSERT INTO sync_items (sync_target, item_type, item_id, item_location, sync_time, remote_item_updated_time, sync_disabled, sync_disabled_reason) VALUES (?, ?, ?, ?, ?, ?, ?)',
+				sql: 'INSERT INTO sync_items (sync_target, item_type, item_id, item_location, sync_time, remote_item_updated_time, sync_disabled, sync_disabled_reason) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
 				params: [syncTarget, itemType, itemId, itemLocation, syncTime, remoteItemUpdatedTime, syncDisabled ? 1 : 0, `${syncDisabledReason}`],
 			},
 		];

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -871,7 +871,7 @@ export default class BaseItem extends BaseModel {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public static updateSyncTimeQueries(syncTarget: number, item: any, syncTime: number, syncDisabled = false, syncDisabledReason = '', itemLocation: number = null, remoteItemUpdatedTime = 0) {
+	public static updateSyncTimeQueries(syncTarget: number, item: any, syncTime: number, remoteItemUpdatedTime = 0, syncDisabled = false, syncDisabledReason = '', itemLocation: number = null) {
 		const itemType = item.type_;
 		const itemId = item.id;
 		if (!itemType || !itemId || syncTime === undefined) throw new Error(sprintf('Invalid parameters in updateSyncTimeQueries(): %d, %s, %d', syncTarget, JSON.stringify(item), syncTime));
@@ -892,7 +892,7 @@ export default class BaseItem extends BaseModel {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	public static async saveSyncTime(syncTarget: number, item: any, syncTime: number, remoteItemUpdatedTime = 0) {
-		const queries = this.updateSyncTimeQueries(syncTarget, item, syncTime, undefined, undefined, undefined, remoteItemUpdatedTime);
+		const queries = this.updateSyncTimeQueries(syncTarget, item, syncTime, remoteItemUpdatedTime);
 		return this.db().transactionExecBatch(queries);
 	}
 
@@ -900,7 +900,7 @@ export default class BaseItem extends BaseModel {
 	public static async saveSyncDisabled(syncTargetId: number, item: any, syncDisabledReason: string, itemLocation: number = null) {
 		const syncTime = 'sync_time' in item ? item.sync_time : 0;
 		const remoteItemUpdatedTime = 'remote_item_updated_time' in item ? item.remote_item_updated_time : 0;
-		const queries = this.updateSyncTimeQueries(syncTargetId, item, syncTime, true, syncDisabledReason, itemLocation, remoteItemUpdatedTime);
+		const queries = this.updateSyncTimeQueries(syncTargetId, item, syncTime, remoteItemUpdatedTime, true, syncDisabledReason, itemLocation);
 		return this.db().transactionExecBatch(queries);
 	}
 

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -28,6 +28,7 @@ export interface ItemsThatNeedDecryptionResult {
 export interface ItemThatNeedSync {
 	id: string;
 	sync_time: number;
+	remote_item_updated_time: number;
 	type_: ModelType;
 	updated_time: number;
 	encryption_applied: number;
@@ -38,6 +39,11 @@ export interface ItemsThatNeedSyncResult {
 	hasMore: boolean;
 	items: ItemThatNeedSync[];
 	neverSyncedItemIds: string[];
+}
+
+export interface RemoteItemMetadata {
+	item_id: string;
+	updated_time: number;
 }
 
 export interface EncryptedItemsStats {
@@ -199,6 +205,20 @@ export default class BaseItem extends BaseModel {
 		const output = [];
 		for (let i = 0; i < temp.length; i++) {
 			output.push(temp[i].item_id);
+		}
+		return output;
+	}
+
+	public static async remoteItemMetadata(syncTarget: number): Promise<Map<string, RemoteItemMetadata>> {
+		if (!syncTarget) throw new Error('No syncTarget specified');
+		const temp = await this.db().selectAll('SELECT item_id, remote_item_updated_time FROM sync_items WHERE sync_time > 0 AND sync_target = ?', [syncTarget]);
+		const output = new Map<string, RemoteItemMetadata>();
+		for (let i = 0; i < temp.length; i++) {
+			const metadata: RemoteItemMetadata = {
+				item_id: temp[i].item_id,
+				updated_time: temp[i].remote_item_updated_time,
+			};
+			output.set(temp[i].item_id, metadata);
 		}
 		return output;
 	}
@@ -751,6 +771,7 @@ export default class BaseItem extends BaseModel {
 
 			if (newLimit > 0) {
 				fieldNames.push('sync_time');
+				fieldNames.push('remote_item_updated_time');
 
 				const sql = sprintf(
 					`
@@ -850,7 +871,7 @@ export default class BaseItem extends BaseModel {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public static updateSyncTimeQueries(syncTarget: number, item: any, syncTime: number, syncDisabled = false, syncDisabledReason = '', itemLocation: number = null) {
+	public static updateSyncTimeQueries(syncTarget: number, item: any, syncTime: number, syncDisabled = false, syncDisabledReason = '', itemLocation: number = null, remoteItemUpdatedTime = 0) {
 		const itemType = item.type_;
 		const itemId = item.id;
 		if (!itemType || !itemId || syncTime === undefined) throw new Error(sprintf('Invalid parameters in updateSyncTimeQueries(): %d, %s, %d', syncTarget, JSON.stringify(item), syncTime));
@@ -863,22 +884,23 @@ export default class BaseItem extends BaseModel {
 				params: [syncTarget, itemType, itemId],
 			},
 			{
-				sql: 'INSERT INTO sync_items (sync_target, item_type, item_id, item_location, sync_time, sync_disabled, sync_disabled_reason) VALUES (?, ?, ?, ?, ?, ?, ?)',
-				params: [syncTarget, itemType, itemId, itemLocation, syncTime, syncDisabled ? 1 : 0, `${syncDisabledReason}`],
+				sql: 'INSERT INTO sync_items (sync_target, item_type, item_id, item_location, sync_time, remote_item_updated_time, sync_disabled, sync_disabled_reason) VALUES (?, ?, ?, ?, ?, ?, ?)',
+				params: [syncTarget, itemType, itemId, itemLocation, syncTime, remoteItemUpdatedTime, syncDisabled ? 1 : 0, `${syncDisabledReason}`],
 			},
 		];
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public static async saveSyncTime(syncTarget: number, item: any, syncTime: number) {
-		const queries = this.updateSyncTimeQueries(syncTarget, item, syncTime);
+	public static async saveSyncTime(syncTarget: number, item: any, syncTime: number, remoteItemUpdatedTime = 0) {
+		const queries = this.updateSyncTimeQueries(syncTarget, item, syncTime, undefined, undefined, undefined, remoteItemUpdatedTime);
 		return this.db().transactionExecBatch(queries);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	public static async saveSyncDisabled(syncTargetId: number, item: any, syncDisabledReason: string, itemLocation: number = null) {
 		const syncTime = 'sync_time' in item ? item.sync_time : 0;
-		const queries = this.updateSyncTimeQueries(syncTargetId, item, syncTime, true, syncDisabledReason, itemLocation);
+		const remoteItemUpdatedTime = 'remote_item_updated_time' in item ? item.remote_item_updated_time : 0;
+		const queries = this.updateSyncTimeQueries(syncTargetId, item, syncTime, true, syncDisabledReason, itemLocation, remoteItemUpdatedTime);
 		return this.db().transactionExecBatch(queries);
 	}
 

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1617,6 +1617,23 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			label: () => _('Proxy timeout (seconds)'),
 			storage: SettingStorage.File,
 		},
+		'sync.detectBasedOnAnyTimestampChanges': {
+			value: false,
+			type: SettingItemType.Bool,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+			show: (settings: any) => {
+				return [
+					SyncTargetRegistry.nameToId('filesystem'),
+					SyncTargetRegistry.nameToId('webdav'),
+				].indexOf(settings['sync.target']) >= 0;
+			},
+			advanced: true,
+			public: true,
+			section: 'sync',
+			label: () => _('Detect changes based on any timestamp change'),
+			description: () => _('Warning: When this is first enabled, it will result in a rescan of all your notes which may take a long time. Enable this if using an external sync tool in combination with Joplin. Enabling this setting will make the sync detect incoming changes based on both timestamp increases and decreases. This will prevent changes not being synced sometimes, which can happen if an external service is syncing to the sync target directory at the same time as Joplin.'),
+			storage: SettingStorage.File,
+		},
 		'sync.wipeOutFailSafe': {
 			value: true,
 			type: SettingItemType.Bool,

--- a/packages/lib/services/database/migrations/49.ts
+++ b/packages/lib/services/database/migrations/49.ts
@@ -1,0 +1,7 @@
+import { SqlQuery } from '../types';
+
+export default (): (SqlQuery|string)[] => {
+	return [
+		'ALTER TABLE sync_items ADD COLUMN remote_item_updated_time INT NOT NULL DEFAULT 0',
+	];
+};

--- a/packages/lib/services/database/migrations/index.ts
+++ b/packages/lib/services/database/migrations/index.ts
@@ -6,6 +6,7 @@ import migration45 from './45';
 import migration46 from './46';
 import migration47 from './47';
 import migration48 from './48';
+import migration49 from './49';
 
 import { Migration } from '../types';
 
@@ -17,6 +18,7 @@ const index: Migration[] = [
 	migration46,
 	migration47,
 	migration48,
+	migration49,
 ];
 
 export default index;

--- a/packages/lib/services/database/types.ts
+++ b/packages/lib/services/database/types.ts
@@ -339,6 +339,7 @@ export interface SyncItemEntity {
   'sync_target'?: number;
   'sync_time'?: number;
   'sync_warning_ignored'?: number;
+  'remote_item_updated_time'?: number;
   'type_'?: number;
 }
 export interface TableFieldEntity {
@@ -444,6 +445,7 @@ export const databaseSchema: DatabaseTables = {
 		sync_target: { type: 'number' },
 		sync_time: { type: 'number' },
 		sync_warning_ignored: { type: 'number' },
+		remote_item_updated_time: { type: 'number' },
 		type_: { type: 'number' },
 	},
 	version: {

--- a/packages/lib/services/synchronizer/utils/handleConflictAction.ts
+++ b/packages/lib/services/synchronizer/utils/handleConflictAction.ts
@@ -26,7 +26,7 @@ export default async (action: SyncAction, ItemClass: typeof BaseItem, remoteExis
 		if (remoteExists) {
 			local = remoteContent;
 
-			const syncTimeQueries = BaseItem.updateSyncTimeQueries(syncTargetId, local, time.unixMs(), undefined, undefined, undefined, remoteContent.updated_time);
+			const syncTimeQueries = BaseItem.updateSyncTimeQueries(syncTargetId, local, time.unixMs(), remoteContent.updated_time);
 			await ItemClass.save(local, { autoTimestamp: false, changeSource: ItemChange.SOURCE_SYNC, nextQueries: syncTimeQueries });
 		} else {
 			await ItemClass.delete(local.id, {
@@ -80,7 +80,7 @@ export default async (action: SyncAction, ItemClass: typeof BaseItem, remoteExis
 
 		if (remoteExists) {
 			local = remoteContent;
-			const syncTimeQueries = BaseItem.updateSyncTimeQueries(syncTargetId, local, time.unixMs(), undefined, undefined, undefined, remoteContent.updated_time);
+			const syncTimeQueries = BaseItem.updateSyncTimeQueries(syncTargetId, local, time.unixMs(), remoteContent.updated_time);
 			await ItemClass.save(local, { autoTimestamp: false, changeSource: ItemChange.SOURCE_SYNC, nextQueries: syncTimeQueries });
 
 			if (local.encryption_applied) dispatch({ type: 'SYNC_GOT_ENCRYPTED_ITEM' });

--- a/packages/lib/services/synchronizer/utils/handleConflictAction.ts
+++ b/packages/lib/services/synchronizer/utils/handleConflictAction.ts
@@ -26,7 +26,7 @@ export default async (action: SyncAction, ItemClass: typeof BaseItem, remoteExis
 		if (remoteExists) {
 			local = remoteContent;
 
-			const syncTimeQueries = BaseItem.updateSyncTimeQueries(syncTargetId, local, time.unixMs());
+			const syncTimeQueries = BaseItem.updateSyncTimeQueries(syncTargetId, local, time.unixMs(), undefined, undefined, undefined, remoteContent.updated_time);
 			await ItemClass.save(local, { autoTimestamp: false, changeSource: ItemChange.SOURCE_SYNC, nextQueries: syncTimeQueries });
 		} else {
 			await ItemClass.delete(local.id, {
@@ -80,7 +80,7 @@ export default async (action: SyncAction, ItemClass: typeof BaseItem, remoteExis
 
 		if (remoteExists) {
 			local = remoteContent;
-			const syncTimeQueries = BaseItem.updateSyncTimeQueries(syncTargetId, local, time.unixMs());
+			const syncTimeQueries = BaseItem.updateSyncTimeQueries(syncTargetId, local, time.unixMs(), undefined, undefined, undefined, remoteContent.updated_time);
 			await ItemClass.save(local, { autoTimestamp: false, changeSource: ItemChange.SOURCE_SYNC, nextQueries: syncTimeQueries });
 
 			if (local.encryption_applied) dispatch({ type: 'SYNC_GOT_ENCRYPTED_ITEM' });

--- a/packages/lib/services/synchronizer/utils/syncDeleteStep.ts
+++ b/packages/lib/services/synchronizer/utils/syncDeleteStep.ts
@@ -32,6 +32,7 @@ export default async (syncTargetId: number, cancelling: boolean, logSyncOperatio
 				if (remoteContent) {
 					remoteContent = await BaseItem.unserialize(remoteContent);
 					const ItemClass = BaseItem.itemClass(item.item_type);
+					// For remote deletion, remoteItemUpdatedTime can be reset to 0
 					let nextQueries = BaseItem.updateSyncTimeQueries(syncTargetId, remoteContent, time.unixMs());
 
 					if (isResource) {


### PR DESCRIPTION
### Background

When syncing to the file system sync in combination with an external sync service such as Syncthing, new files with a timestamp older than the last sync timestamp may get silently ignored (instead of being pulled into Joplin) if the external sync service syncs at the same time as the Joplin sync.

This is due to the basic delta algorithm's reliance on file timestamps, which presents a problem described well in this post https://discourse.joplinapp.org/t/photos-sometimes-not-syncing-syncthing-android-mac/47083/4:
> The main difference between filesystem sync and other types of sync is that with the latter, you've got a single source that is used by all devices, and the whole synchronisation mechanism is built around it. In the case of filesystem sync, there is no single source, but rather the filesystem sync path on each device acts as its own source. When there is just a single source, Joplin can assume that its state is always complete. However, with filesystem sync, there is no such guarantee, and this eventually leads to the issue at hand.

This PR resolves the issue by providing a new setting, which when enabled will use a modified sync algorithm for the basic delta. When enabled initially, it will need to do a re-scan of all local notes in order to store the file timestamps of all the sync target items. However, once this is done, items will not be re-scanned unless the timestamp of a file in the sync target directory has changed. When using the new algorithm, it is backwards compatible if the setting is turned back off, and is compatible with other clients which do not have the setting enabled or are on older version of Joplin without the new setting. The requirement for a full or partial re-scan on enabling of the setting, also applies when re-enabling the setting if switching back and forth between enabled and disabled and syncing changes between toggling the setting.

This fixes the longstanding issue https://github.com/laurent22/joplin/issues/6517

### Changes

1. A new 'Detect changes based on any timestamp change' setting has been added to the advanced sync settings. This is only available when using file system sync or WebDAV, as it is not necessary for other sync targets
2. The basic delta function (for both old and new behaviour) has been changed to only scan files at the root of the sync target directory which have a 32 character long filename and the md extension. Whilst not necessary for the old algorithm, it is unnecessary to process any other items, so the logic might as well be shared. For the new algorithm, this change will prevent items in the sync target directory which are not readable by Joplin (eg. Syncthing metadata files) from being fetched on every sync
3. A new database column in the sqlite database has been added to store the modified time of files in the sync target directory. This is defaulted to 0 for all existing local items. When the new setting is enabled for the first time, the modified time of all relevant files in the sync target directory are stored against the local items via the sync_items table
4. When the setting is enabled, the basic delta function uses a new algorithm. This new algorithm does not rely on timestamps increasing to determine whether new changes need to be synced, but will consider an earlier timestamp to be a new change as well, because the change in the previous point allows current file timestamps to be tracked. After detecting files with changes to timestamp in either direction, the existing logic in the rest of the sync algorithm will determine whether local changes actually need to be overwritten, or if there is a conflict. The only way a change can get ignored by the sync using this new algorithm is if 2 sync clients synced conflicting changes at exactly the same millisecond. However this is very unlikely to happen, in comparison to the likelihood of changes getting missed when using the old algorithm

At a basic level it works like so:
  - For each eligible item, check whether a matching item exists locally. If it does, set its remote_item_updated_time in memory
  - If the remote_item_updated_time matches the modified time on the file, the item has already been synced, so will note be fetched
  - If the remote_item_updated_time does not match the modified time on the file, the item needs to be fetched. Then the rest of the sync algorithm will update the local item if the updated_time within the remote md is later than in the local one, or if it is earlier, create a conflict etc
  - If no matching item exists locally, the item needs to be fetched. Then the rest of the sync algorithm will create the local item
  - Local deletions are managed based on the lack of a matching item remote item which exists locally. No change has been made to this behaviour

### Testing

- When the new setting is first enabled, I have verified that it will update the remote_item_updated_time column for every sync item to match the corresponding modified date on the file in the sync target directory. This ensures that after the initial scan, items which have not changed will no longer be fetched on each run of the sync
- I have ensured that syncing using the new algorithm is compatible when syncing with older Joplin clients without the new setting, and after enabling the new setting, if I disable it again, no re-scan is required and the sync will continue to work as before
- With the new setting enabled or disabled, I have ensured that all creates, updates and fetches are cleared after 1 or 2 manual syncs, when syncing changes in both directions between 2 clients, regardless of whether the file timestamp in the sync target directory is earlier, equal to or later than the timestamp being compared to
- I have ensured that with the new setting enabled, when following the reproduction steps in the description of https://github.com/laurent22/joplin/issues/6517, I am able to receive the incoming item, and I am then able to sync every future change to the item both ways between 2 clients. In addition to creating new md files based on the production steps, I can also modify an existing md file, increment the updated_time within the file and make a change to the note contents, and this results in the change being detected by the sync and updated locally
- I have ensured that if additional files are added to the root of the sync target directory, they are ignored by the sync unless the filename is 32 chars long with an md extension
- The basic delta creates info log entries in the format:
Synchronizer: BasicDelta: Report: {"timestamp":1756248482745,"older":27,"newer":0,"equal":1}
I have verified with the new code, the log entry returns a count of only the valid md files in the root directory (split between older, newer and equal). This is because any additional files, including the mandatory info.json, are now excluded from the output of the basic delta. When the new setting is enabled, the count will be distributed differently across older, newer and equal, but the total count is equivalent, and the log entry includes '(with syncBasedOnTimestampChanges)' text in it
- I have verified that the new setting is only available in the UI for the file system sync and WebDAV sync targets

Videos:

These demonstrate syncing between the code in this PR as a dev build, and the Joplin 3.4.5 production build

Part 1:

https://github.com/user-attachments/assets/27f4e002-6790-4b66-9040-9ea66ee846c3

Part 2:

https://github.com/user-attachments/assets/ac829f16-f67a-4c7e-8afc-103866150858