### PR TITLE
Mobile: WIP attempt at background sync

### DIFF
--- a/packages/app-mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/app-mobile/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,12 @@
 	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 	<uses-permission android:name="android.permission.RECORD_AUDIO" />
 
+	<!-- Foreground service permissions -->
+	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+	<uses-permission android:name="android.permission.WAKE_LOCK" />
+	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+	<uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+
 	<!-- Make these features optional to enable Chromebooks -->
 	<!-- https://github.com/laurent22/joplin/issues/37 -->
 	<uses-feature android:name="android.hardware.camera" android:required="false" />
@@ -114,6 +120,25 @@
 			</intent-filter>
 			<!-- /EXTERNAL LINK -->
 		</activity>
+
+		<!-- Foreground service metadata and services -->
+		<meta-data
+			android:name="com.kirenpaul.foregroundservice.notification_channel_name"
+			android:value="Foreground Service" />
+		<meta-data
+			android:name="com.kirenpaul.foregroundservice.notification_channel_description"
+			android:value="Persistent notification for foreground service" />
+		<meta-data
+			android:name="com.kirenpaul.foregroundservice.notification_color"
+			android:resource="@color/notification_color" />
+
+		<service
+			android:name="com.kirenpaul.foregroundservice.ForegroundService"
+			android:exported="false"
+			android:foregroundServiceType="dataSync|location|mediaPlayback" />
+		<service
+			android:name="com.kirenpaul.foregroundservice.ForegroundServiceTask"
+			android:exported="false" />
 
 	</application>
 

--- a/packages/app-mobile/index.web.ts
+++ b/packages/app-mobile/index.web.ts
@@ -1,6 +1,6 @@
 import './utils/polyfills';
 import './utils/initReact';
-import { AppRegistry } from 'react-native';
+import { AppRegistry, PermissionsAndroid, Platform } from 'react-native';
 import Root from './root';
 import Setting from '@joplin/lib/models/Setting';
 import Note from '@joplin/lib/models/Note';
@@ -12,8 +12,21 @@ import DecryptionWorker from '@joplin/lib/services/DecryptionWorker';
 import PluginService from '@joplin/lib/services/plugins/PluginService';
 import Tag from '@joplin/lib/models/Tag';
 import SearchEngine from '@joplin/lib/services/search/SearchEngine';
+import ForegroundService, { StartServiceConfig, TaskOptions } from 'react-native-foreground-service-turbo';
+import { initializeRegistry } from '@joplin/lib/registry';
 
 require('./web/rnVectorIconsSetup.js');
+
+ForegroundService.register();
+
+initializeRegistry({
+  foregroundService: {
+    start: (options: StartServiceConfig) => ForegroundService.start(options),
+    stop: () => ForegroundService.stop(),
+    add_task: (task: () => Promise<void> | void, options: TaskOptions) => ForegroundService.add_task(task, options),
+    remove_task: (id: string) => ForegroundService.remove_task(id),
+  },
+});
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Necessary until Root doesn't extend `any`
 AppRegistry.registerComponent('Joplin', () => Root as any);
@@ -83,6 +96,18 @@ const keepAppAboveKeyboard = () => {
 	}
 };
 
+const requestNotificationPermission = async () => {
+	if (Platform.OS === 'android' && Platform.Version >= 33) {
+		const result = await PermissionsAndroid.request(
+			PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS
+		);
+
+		return result === PermissionsAndroid.RESULTS.GRANTED;
+	}
+
+	return true;
+}
+
 addEventListener('DOMContentLoaded', async () => {
 	if (window.crossOriginIsolated === false) {
 		// Currently, reloading should be handled by serviceWorker.ts -- this change is left for
@@ -94,6 +119,7 @@ addEventListener('DOMContentLoaded', async () => {
 
 	keepAppAboveKeyboard();
 	void requestPersistentStorage();
+	void requestNotificationPermission();
 
 	AppRegistry.runApplication('Joplin', {
 		rootTag: document.querySelector('#root'),

--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -65,6 +65,7 @@
     "react-native-device-info": "14.1.1",
     "react-native-dropdownalert": "5.2.0",
     "react-native-file-viewer": "2.1.5",
+    "react-native-foreground-service-turbo": "github:paulkiren/react-native-foreground-service-turbo",
     "react-native-get-random-values": "1.11.0",
     "react-native-image-picker": "8.2.1",
     "react-native-localize": "3.6.1",

--- a/packages/lib/registry.ts
+++ b/packages/lib/registry.ts
@@ -5,6 +5,34 @@ import SyncTargetRegistry from './SyncTargetRegistry';
 import { AnyAction, Dispatch } from 'redux';
 import Synchronizer from './Synchronizer';
 
+export interface StartServiceConfig {
+	id: number;
+	title?: string;
+	message?: string;
+	serviceType?: string;
+	button?: {
+		text: string;
+		onPressEvent: string;
+	};
+	progress?: {
+		max: number;
+		curr: number;
+	};
+}
+
+export interface TaskOptions {
+	delay?: number;
+	onLoop?: boolean;
+	taskId?: string;
+}
+
+export interface ForegroundService {
+	start(options: StartServiceConfig): Promise<void>;
+	stop(): Promise<void>;
+	add_task(task: () => Promise<void>, options: TaskOptions): void;
+	remove_task(id: string): void;
+}
+
 class Registry {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -24,6 +52,11 @@ class Registry {
 	private db_: any;
 	private isOnMobileData_ = false;
 	private dispatch_: Dispatch = (() => {}) as Dispatch;
+	private foregroundService_: ForegroundService | null = null;
+
+	public setForegroundService(service: ForegroundService) {
+		this.foregroundService_ = service;
+	}
 
 	public logger() {
 		if (!this.logger_) {
@@ -209,7 +242,7 @@ class Registry {
 									Setting.setValue(contextKey, JSON.stringify(newContext));
 								};
 							}
-							newContext = await sync.start(options);
+							newContext = await this.startSync(sync, options);
 							Setting.setValue(contextKey, JSON.stringify(newContext));
 						} catch (error) {
 							if (error.code === 'alreadyStarted') {
@@ -248,6 +281,45 @@ class Registry {
 			this.schedSyncCalls_.pop();
 		}
 	};
+
+	private async startSync(sync: any, options: any) {
+		let resolveDone: (value: any) => void;
+
+		const donePromise = new Promise(resolve => {
+			resolveDone = resolve;
+		});
+
+		const fg = this.foregroundService_;
+
+		if (!fg) {
+			// fallback: run without foreground service
+			const result = await sync.start(options);
+			return result;
+		}
+
+		await fg.start({
+			id: 1,
+			title: 'Synchronising data',
+			message: 'Synchronising...',
+			serviceType: 'dataSync',
+			button: { text: 'Cancel', onPressEvent: 'cancel' },
+		});
+
+		fg.add_task(
+			async () => {
+				const result = await sync.start(options);
+			
+				if (result) {
+					fg.remove_task('synchronise');
+					await fg.stop();
+					resolveDone(result);
+				}
+			},
+			{ delay: 0, onLoop: true, taskId: 'synchronise' }
+		);
+
+		return donePromise;
+	}
 
 	public setupRecurrentSync() {
 		this.setupRecurrentCalls_.push(true);
@@ -321,3 +393,11 @@ const reg = new Registry();
 
 // eslint-disable-next-line import/prefer-default-export
 export { reg };
+
+export function initializeRegistry(deps: {
+	foregroundService?: ForegroundService;
+}) {
+	if (deps.foregroundService) {
+		reg.setForegroundService(deps.foregroundService);
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12848,6 +12848,7 @@ __metadata:
     react-native-device-info: "npm:14.1.1"
     react-native-dropdownalert: "npm:5.2.0"
     react-native-file-viewer: "npm:2.1.5"
+    react-native-foreground-service-turbo: "github:paulkiren/react-native-foreground-service-turbo"
     react-native-get-random-values: "npm:1.11.0"
     react-native-image-picker: "npm:8.2.1"
     react-native-localize: "npm:3.6.1"
@@ -49711,6 +49712,16 @@ __metadata:
   peerDependencies:
     react-native: ">=0.47"
   checksum: 10/0a99496d193dedf51e3773a0703a79b7517b5266df49bcf994dafaf845705112ed8e11a1ffde2e923d3fbea6afbda559c057b81e9711fe4116ff09eac1f30f23
+  languageName: node
+  linkType: hard
+
+"react-native-foreground-service-turbo@github:paulkiren/react-native-foreground-service-turbo":
+  version: 0.1.0
+  resolution: "react-native-foreground-service-turbo@https://github.com/paulkiren/react-native-foreground-service-turbo.git#commit=70cdd21d4a71790b8fc93c39a0b4062f00dce500"
+  peerDependencies:
+    react: "*"
+    react-native: ">=0.68.0"
+  checksum: 10/3bd71a2ae31ed176de1454ffda5b3fb42e87c3aa3e09abfcc0d963dbaec9e524a581ef8474fb9ae8bab5da178828250616eec8e821bd86832ea571ecd803a77e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Kotlin does not build. react-native-background-actions would probably be a better option anyway as it supports something similar to a foreground task on iOS as well, however there is still the question of whether the required maintenance for the feature is acceptable, but this suggests it is still on the cards https://discourse.joplinapp.org/t/sync-in-background/38097/6